### PR TITLE
Murisi/reset rewards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,7 +2261,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 [[package]]
 name = "masp_note_encryption"
 version = "1.3.0"
-source = "git+https://github.com/anoma/masp?rev=c140433d75e4cfa436a590f57c2d67870cbb6e31#c140433d75e4cfa436a590f57c2d67870cbb6e31"
+source = "git+https://github.com/anoma/masp?rev=0337143a09f700d0566a8f8427ef5ba0a8aef2c5#0337143a09f700d0566a8f8427ef5ba0a8aef2c5"
 dependencies = [
  "borsh",
  "chacha20",
@@ -2274,7 +2274,7 @@ dependencies = [
 [[package]]
 name = "masp_primitives"
 version = "1.3.0"
-source = "git+https://github.com/anoma/masp?rev=c140433d75e4cfa436a590f57c2d67870cbb6e31#c140433d75e4cfa436a590f57c2d67870cbb6e31"
+source = "git+https://github.com/anoma/masp?rev=0337143a09f700d0566a8f8427ef5ba0a8aef2c5#0337143a09f700d0566a8f8427ef5ba0a8aef2c5"
 dependencies = [
  "aes",
  "bip0039",
@@ -2305,7 +2305,7 @@ dependencies = [
 [[package]]
 name = "masp_proofs"
 version = "1.3.0"
-source = "git+https://github.com/anoma/masp?rev=c140433d75e4cfa436a590f57c2d67870cbb6e31#c140433d75e4cfa436a590f57c2d67870cbb6e31"
+source = "git+https://github.com/anoma/masp?rev=0337143a09f700d0566a8f8427ef5ba0a8aef2c5#0337143a09f700d0566a8f8427ef5ba0a8aef2c5"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -2448,7 +2448,7 @@ dependencies = [
 [[package]]
 name = "namada_account"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
+source = "git+https://github.com/anoma/namada?rev=db92cfbba3740134c6322603900c36f0ee42c06c#db92cfbba3740134c6322603900c36f0ee42c06c"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2460,7 +2460,7 @@ dependencies = [
 [[package]]
 name = "namada_controller"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
+source = "git+https://github.com/anoma/namada?rev=db92cfbba3740134c6322603900c36f0ee42c06c#db92cfbba3740134c6322603900c36f0ee42c06c"
 dependencies = [
  "namada_core",
  "smooth-operator",
@@ -2470,7 +2470,7 @@ dependencies = [
 [[package]]
 name = "namada_core"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
+source = "git+https://github.com/anoma/namada?rev=db92cfbba3740134c6322603900c36f0ee42c06c#db92cfbba3740134c6322603900c36f0ee42c06c"
 dependencies = [
  "bech32",
  "borsh",
@@ -2514,7 +2514,7 @@ dependencies = [
 [[package]]
 name = "namada_events"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
+source = "git+https://github.com/anoma/namada?rev=db92cfbba3740134c6322603900c36f0ee42c06c#db92cfbba3740134c6322603900c36f0ee42c06c"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2528,7 +2528,7 @@ dependencies = [
 [[package]]
 name = "namada_gas"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
+source = "git+https://github.com/anoma/namada?rev=db92cfbba3740134c6322603900c36f0ee42c06c#db92cfbba3740134c6322603900c36f0ee42c06c"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2541,7 +2541,7 @@ dependencies = [
 [[package]]
 name = "namada_governance"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
+source = "git+https://github.com/anoma/namada?rev=db92cfbba3740134c6322603900c36f0ee42c06c#db92cfbba3740134c6322603900c36f0ee42c06c"
 dependencies = [
  "borsh",
  "itertools 0.14.0",
@@ -2564,7 +2564,7 @@ dependencies = [
 [[package]]
 name = "namada_ibc"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
+source = "git+https://github.com/anoma/namada?rev=db92cfbba3740134c6322603900c36f0ee42c06c#db92cfbba3740134c6322603900c36f0ee42c06c"
 dependencies = [
  "borsh",
  "data-encoding",
@@ -2599,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "namada_macros"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
+source = "git+https://github.com/anoma/namada?rev=db92cfbba3740134c6322603900c36f0ee42c06c#db92cfbba3740134c6322603900c36f0ee42c06c"
 dependencies = [
  "data-encoding",
  "proc-macro2",
@@ -2611,7 +2611,7 @@ dependencies = [
 [[package]]
 name = "namada_merkle_tree"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
+source = "git+https://github.com/anoma/namada?rev=db92cfbba3740134c6322603900c36f0ee42c06c#db92cfbba3740134c6322603900c36f0ee42c06c"
 dependencies = [
  "borsh",
  "eyre",
@@ -2626,7 +2626,7 @@ dependencies = [
 [[package]]
 name = "namada_parameters"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
+source = "git+https://github.com/anoma/namada?rev=db92cfbba3740134c6322603900c36f0ee42c06c#db92cfbba3740134c6322603900c36f0ee42c06c"
 dependencies = [
  "namada_core",
  "namada_macros",
@@ -2641,7 +2641,7 @@ dependencies = [
 [[package]]
 name = "namada_proof_of_stake"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
+source = "git+https://github.com/anoma/namada?rev=db92cfbba3740134c6322603900c36f0ee42c06c#db92cfbba3740134c6322603900c36f0ee42c06c"
 dependencies = [
  "borsh",
  "itertools 0.14.0",
@@ -2665,7 +2665,7 @@ dependencies = [
 [[package]]
 name = "namada_replay_protection"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
+source = "git+https://github.com/anoma/namada?rev=db92cfbba3740134c6322603900c36f0ee42c06c#db92cfbba3740134c6322603900c36f0ee42c06c"
 dependencies = [
  "namada_core",
 ]
@@ -2673,7 +2673,7 @@ dependencies = [
 [[package]]
 name = "namada_shielded_token"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
+source = "git+https://github.com/anoma/namada?rev=db92cfbba3740134c6322603900c36f0ee42c06c#db92cfbba3740134c6322603900c36f0ee42c06c"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2710,7 +2710,7 @@ dependencies = [
 [[package]]
 name = "namada_state"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
+source = "git+https://github.com/anoma/namada?rev=db92cfbba3740134c6322603900c36f0ee42c06c#db92cfbba3740134c6322603900c36f0ee42c06c"
 dependencies = [
  "borsh",
  "clru",
@@ -2733,7 +2733,7 @@ dependencies = [
 [[package]]
 name = "namada_storage"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
+source = "git+https://github.com/anoma/namada?rev=db92cfbba3740134c6322603900c36f0ee42c06c#db92cfbba3740134c6322603900c36f0ee42c06c"
 dependencies = [
  "borsh",
  "itertools 0.14.0",
@@ -2752,7 +2752,7 @@ dependencies = [
 [[package]]
 name = "namada_systems"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
+source = "git+https://github.com/anoma/namada?rev=db92cfbba3740134c6322603900c36f0ee42c06c#db92cfbba3740134c6322603900c36f0ee42c06c"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -2762,7 +2762,7 @@ dependencies = [
 [[package]]
 name = "namada_token"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
+source = "git+https://github.com/anoma/namada?rev=db92cfbba3740134c6322603900c36f0ee42c06c#db92cfbba3740134c6322603900c36f0ee42c06c"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2780,7 +2780,7 @@ dependencies = [
 [[package]]
 name = "namada_trans_token"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
+source = "git+https://github.com/anoma/namada?rev=db92cfbba3740134c6322603900c36f0ee42c06c#db92cfbba3740134c6322603900c36f0ee42c06c"
 dependencies = [
  "konst",
  "namada_core",
@@ -2797,7 +2797,7 @@ dependencies = [
 [[package]]
 name = "namada_tx"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
+source = "git+https://github.com/anoma/namada?rev=db92cfbba3740134c6322603900c36f0ee42c06c#db92cfbba3740134c6322603900c36f0ee42c06c"
 dependencies = [
  "ark-bls12-381",
  "bitflags",
@@ -2826,7 +2826,7 @@ dependencies = [
 [[package]]
 name = "namada_tx_env"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
+source = "git+https://github.com/anoma/namada?rev=db92cfbba3740134c6322603900c36f0ee42c06c#db92cfbba3740134c6322603900c36f0ee42c06c"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -2836,7 +2836,7 @@ dependencies = [
 [[package]]
 name = "namada_tx_prelude"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
+source = "git+https://github.com/anoma/namada?rev=db92cfbba3740134c6322603900c36f0ee42c06c#db92cfbba3740134c6322603900c36f0ee42c06c"
 dependencies = [
  "borsh",
  "namada_account",
@@ -2858,7 +2858,7 @@ dependencies = [
 [[package]]
 name = "namada_vm_env"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
+source = "git+https://github.com/anoma/namada?rev=db92cfbba3740134c6322603900c36f0ee42c06c#db92cfbba3740134c6322603900c36f0ee42c06c"
 dependencies = [
  "namada_core",
 ]
@@ -2866,7 +2866,7 @@ dependencies = [
 [[package]]
 name = "namada_vp"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
+source = "git+https://github.com/anoma/namada?rev=db92cfbba3740134c6322603900c36f0ee42c06c#db92cfbba3740134c6322603900c36f0ee42c06c"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -2882,7 +2882,7 @@ dependencies = [
 [[package]]
 name = "namada_vp_env"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
+source = "git+https://github.com/anoma/namada?rev=db92cfbba3740134c6322603900c36f0ee42c06c#db92cfbba3740134c6322603900c36f0ee42c06c"
 dependencies = [
  "derivative",
  "masp_primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,7 +2261,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 [[package]]
 name = "masp_note_encryption"
 version = "1.3.0"
-source = "git+https://github.com/anoma/masp?rev=d38ab0e9bbf5b7161f8e951e5302b87da867aa4d#d38ab0e9bbf5b7161f8e951e5302b87da867aa4d"
+source = "git+https://github.com/anoma/masp?rev=c140433d75e4cfa436a590f57c2d67870cbb6e31#c140433d75e4cfa436a590f57c2d67870cbb6e31"
 dependencies = [
  "borsh",
  "chacha20",
@@ -2274,7 +2274,7 @@ dependencies = [
 [[package]]
 name = "masp_primitives"
 version = "1.3.0"
-source = "git+https://github.com/anoma/masp?rev=d38ab0e9bbf5b7161f8e951e5302b87da867aa4d#d38ab0e9bbf5b7161f8e951e5302b87da867aa4d"
+source = "git+https://github.com/anoma/masp?rev=c140433d75e4cfa436a590f57c2d67870cbb6e31#c140433d75e4cfa436a590f57c2d67870cbb6e31"
 dependencies = [
  "aes",
  "bip0039",
@@ -2305,7 +2305,7 @@ dependencies = [
 [[package]]
 name = "masp_proofs"
 version = "1.3.0"
-source = "git+https://github.com/anoma/masp?rev=d38ab0e9bbf5b7161f8e951e5302b87da867aa4d#d38ab0e9bbf5b7161f8e951e5302b87da867aa4d"
+source = "git+https://github.com/anoma/masp?rev=c140433d75e4cfa436a590f57c2d67870cbb6e31#c140433d75e4cfa436a590f57c2d67870cbb6e31"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -2448,7 +2448,7 @@ dependencies = [
 [[package]]
 name = "namada_account"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
+source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2460,7 +2460,7 @@ dependencies = [
 [[package]]
 name = "namada_controller"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
+source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
 dependencies = [
  "namada_core",
  "smooth-operator",
@@ -2470,7 +2470,7 @@ dependencies = [
 [[package]]
 name = "namada_core"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
+source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
 dependencies = [
  "bech32",
  "borsh",
@@ -2514,7 +2514,7 @@ dependencies = [
 [[package]]
 name = "namada_events"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
+source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2528,7 +2528,7 @@ dependencies = [
 [[package]]
 name = "namada_gas"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
+source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2541,7 +2541,7 @@ dependencies = [
 [[package]]
 name = "namada_governance"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
+source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
 dependencies = [
  "borsh",
  "itertools 0.14.0",
@@ -2564,7 +2564,7 @@ dependencies = [
 [[package]]
 name = "namada_ibc"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
+source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
 dependencies = [
  "borsh",
  "data-encoding",
@@ -2599,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "namada_macros"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
+source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
 dependencies = [
  "data-encoding",
  "proc-macro2",
@@ -2611,7 +2611,7 @@ dependencies = [
 [[package]]
 name = "namada_merkle_tree"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
+source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
 dependencies = [
  "borsh",
  "eyre",
@@ -2626,7 +2626,7 @@ dependencies = [
 [[package]]
 name = "namada_parameters"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
+source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
 dependencies = [
  "namada_core",
  "namada_macros",
@@ -2641,7 +2641,7 @@ dependencies = [
 [[package]]
 name = "namada_proof_of_stake"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
+source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
 dependencies = [
  "borsh",
  "itertools 0.14.0",
@@ -2665,7 +2665,7 @@ dependencies = [
 [[package]]
 name = "namada_replay_protection"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
+source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
 dependencies = [
  "namada_core",
 ]
@@ -2673,7 +2673,7 @@ dependencies = [
 [[package]]
 name = "namada_shielded_token"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
+source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2710,7 +2710,7 @@ dependencies = [
 [[package]]
 name = "namada_state"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
+source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
 dependencies = [
  "borsh",
  "clru",
@@ -2733,7 +2733,7 @@ dependencies = [
 [[package]]
 name = "namada_storage"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
+source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
 dependencies = [
  "borsh",
  "itertools 0.14.0",
@@ -2752,7 +2752,7 @@ dependencies = [
 [[package]]
 name = "namada_systems"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
+source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -2762,7 +2762,7 @@ dependencies = [
 [[package]]
 name = "namada_token"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
+source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2780,7 +2780,7 @@ dependencies = [
 [[package]]
 name = "namada_trans_token"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
+source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
 dependencies = [
  "konst",
  "namada_core",
@@ -2797,7 +2797,7 @@ dependencies = [
 [[package]]
 name = "namada_tx"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
+source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
 dependencies = [
  "ark-bls12-381",
  "bitflags",
@@ -2826,7 +2826,7 @@ dependencies = [
 [[package]]
 name = "namada_tx_env"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
+source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -2836,7 +2836,7 @@ dependencies = [
 [[package]]
 name = "namada_tx_prelude"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
+source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
 dependencies = [
  "borsh",
  "namada_account",
@@ -2858,7 +2858,7 @@ dependencies = [
 [[package]]
 name = "namada_vm_env"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
+source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
 dependencies = [
  "namada_core",
 ]
@@ -2866,7 +2866,7 @@ dependencies = [
 [[package]]
 name = "namada_vp"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
+source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -2882,7 +2882,7 @@ dependencies = [
 [[package]]
 name = "namada_vp_env"
 version = "0.47.0"
-source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
+source = "git+https://github.com/anoma/namada?rev=66e512225da9c5f13d9e23647cf9c07ab987f1eb#66e512225da9c5f13d9e23647cf9c07ab987f1eb"
 dependencies = [
  "derivative",
  "masp_primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,6 +54,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -66,84 +84,124 @@ checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "ark-bls12-381"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65be532f9dd1e98ad0150b037276cde464c6f371059e6dd02c0222395761f6aa"
+checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
 dependencies = [
  "ark-ec",
  "ark-ff",
+ "ark-serialize",
  "ark-std",
 ]
 
 [[package]]
 name = "ark-ec"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea978406c4b1ca13c2db2373b05cc55429c3575b8b21f1b9ee859aa5b03dd42"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
 dependencies = [
+ "ahash 0.8.11",
  "ark-ff",
+ "ark-poly",
  "ark-serialize",
  "ark-std",
- "derivative",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.0",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
  "num-traits",
  "zeroize",
 ]
 
 [[package]]
 name = "ark-ff"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
 dependencies = [
  "ark-ff-asm",
  "ark-ff-macros",
  "ark-serialize",
  "ark-std",
- "derivative",
+ "arrayvec",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
  "num-bigint",
  "num-traits",
  "paste",
- "rustc_version 0.3.3",
  "zeroize",
 ]
 
 [[package]]
 name = "ark-ff-asm"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "ark-ff-macros"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
  "num-bigint",
  "num-traits",
+ "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+dependencies = [
+ "ahash 0.8.11",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.0",
 ]
 
 [[package]]
 name = "ark-serialize"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
+ "ark-serialize-derive",
  "ark-std",
- "digest 0.9.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "ark-std"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
  "rand",
@@ -219,9 +277,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bech32"
-version = "0.8.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bellman"
@@ -345,6 +403,16 @@ dependencies = [
  "ff",
  "rand_core",
  "subtle",
+]
+
+[[package]]
+name = "bnum"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ed1ec45f6ef6e8d1125cc2c2fec8f8fe7d4fa5b262f15885fdccb9e26f0f15"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -851,6 +919,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +967,26 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
 
 [[package]]
 name = "equivalent"
@@ -1211,7 +1311,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -1219,6 +1319,9 @@ name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "heapless"
@@ -1228,7 +1331,7 @@ checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
  "hash32",
- "rustc_version 0.4.1",
+ "rustc_version",
  "serde",
  "spin",
  "stable_deref_trait",
@@ -1890,13 +1993,13 @@ dependencies = [
 
 [[package]]
 name = "impl-num-traits"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951641f13f873bff03d4bf19ae8bec531935ac0ac2cc775f84d7edfdcfed3f17"
+checksum = "803d15461ab0dcc56706adf266158acbc44ccf719bf7d0af30705f58b90a4b8c"
 dependencies = [
  "integer-sqrt",
  "num-traits",
- "uint 0.9.5",
+ "uint 0.10.0",
 ]
 
 [[package]]
@@ -2157,9 +2260,8 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "masp_note_encryption"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9736dbd86140a9d6711b464297a87af9cc0ae485d73a956c595f1bc1f6a7920"
+version = "1.3.0"
+source = "git+https://github.com/anoma/masp?rev=d38ab0e9bbf5b7161f8e951e5302b87da867aa4d#d38ab0e9bbf5b7161f8e951e5302b87da867aa4d"
 dependencies = [
  "borsh",
  "chacha20",
@@ -2171,9 +2273,8 @@ dependencies = [
 
 [[package]]
 name = "masp_primitives"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb184254ca5cd5fb12e11b81a6a0d6b955d98c7263eae11057f669c31c7123c"
+version = "1.3.0"
+source = "git+https://github.com/anoma/masp?rev=d38ab0e9bbf5b7161f8e951e5302b87da867aa4d#d38ab0e9bbf5b7161f8e951e5302b87da867aa4d"
 dependencies = [
  "aes",
  "bip0039",
@@ -2203,9 +2304,8 @@ dependencies = [
 
 [[package]]
 name = "masp_proofs"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb23ccc5e4781636f6a7b2e720f60f31e53e534d1abb2b0ac5e86eb099c14"
+version = "1.3.0"
+source = "git+https://github.com/anoma/masp?rev=d38ab0e9bbf5b7161f8e951e5302b87da867aa4d#d38ab0e9bbf5b7161f8e951e5302b87da867aa4d"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -2347,8 +2447,8 @@ dependencies = [
 
 [[package]]
 name = "namada_account"
-version = "0.47.1"
-source = "git+https://github.com/anoma/namada?tag=libs-v0.47.1#c934e9f35b1c0053d6db0ebbb4279e53c599e928"
+version = "0.47.0"
+source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2359,18 +2459,18 @@ dependencies = [
 
 [[package]]
 name = "namada_controller"
-version = "0.47.1"
-source = "git+https://github.com/anoma/namada?tag=libs-v0.47.1#c934e9f35b1c0053d6db0ebbb4279e53c599e928"
+version = "0.47.0"
+source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
 dependencies = [
  "namada_core",
  "smooth-operator",
- "thiserror 1.0.64",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "namada_core"
-version = "0.47.1"
-source = "git+https://github.com/anoma/namada?tag=libs-v0.47.1#c934e9f35b1c0053d6db0ebbb4279e53c599e928"
+version = "0.47.0"
+source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
 dependencies = [
  "bech32",
  "borsh",
@@ -2399,52 +2499,52 @@ dependencies = [
  "ripemd",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "smooth-operator",
  "tendermint",
  "tendermint-proto",
- "thiserror 1.0.64",
+ "thiserror 2.0.11",
  "tiny-keccak",
  "tracing",
- "uint 0.9.5",
+ "uint 0.10.0",
  "usize-set",
  "zeroize",
 ]
 
 [[package]]
 name = "namada_events"
-version = "0.47.1"
-source = "git+https://github.com/anoma/namada?tag=libs-v0.47.1#c934e9f35b1c0053d6db0ebbb4279e53c599e928"
+version = "0.47.0"
+source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
 dependencies = [
  "borsh",
  "namada_core",
  "namada_macros",
  "serde",
  "serde_json",
- "thiserror 1.0.64",
+ "thiserror 2.0.11",
  "tracing",
 ]
 
 [[package]]
 name = "namada_gas"
-version = "0.47.1"
-source = "git+https://github.com/anoma/namada?tag=libs-v0.47.1#c934e9f35b1c0053d6db0ebbb4279e53c599e928"
+version = "0.47.0"
+source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
 dependencies = [
  "borsh",
  "namada_core",
  "namada_events",
  "namada_macros",
  "serde",
- "thiserror 1.0.64",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "namada_governance"
-version = "0.47.1"
-source = "git+https://github.com/anoma/namada?tag=libs-v0.47.1#c934e9f35b1c0053d6db0ebbb4279e53c599e928"
+version = "0.47.0"
+source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
 dependencies = [
  "borsh",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "konst",
  "namada_account",
  "namada_core",
@@ -2457,14 +2557,14 @@ dependencies = [
  "serde",
  "serde_json",
  "smooth-operator",
- "thiserror 1.0.64",
+ "thiserror 2.0.11",
  "tracing",
 ]
 
 [[package]]
 name = "namada_ibc"
-version = "0.47.1"
-source = "git+https://github.com/anoma/namada?tag=libs-v0.47.1#c934e9f35b1c0053d6db0ebbb4279e53c599e928"
+version = "0.47.0"
+source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
 dependencies = [
  "borsh",
  "data-encoding",
@@ -2490,28 +2590,28 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "smooth-operator",
- "thiserror 1.0.64",
+ "thiserror 2.0.11",
  "tracing",
 ]
 
 [[package]]
 name = "namada_macros"
-version = "0.47.1"
-source = "git+https://github.com/anoma/namada?tag=libs-v0.47.1#c934e9f35b1c0053d6db0ebbb4279e53c599e928"
+version = "0.47.0"
+source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
 dependencies = [
  "data-encoding",
  "proc-macro2",
  "quote",
- "sha2 0.9.9",
- "syn 1.0.109",
+ "sha2 0.10.8",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "namada_merkle_tree"
-version = "0.47.1"
-source = "git+https://github.com/anoma/namada?tag=libs-v0.47.1#c934e9f35b1c0053d6db0ebbb4279e53c599e928"
+version = "0.47.0"
+source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
 dependencies = [
  "borsh",
  "eyre",
@@ -2520,13 +2620,13 @@ dependencies = [
  "namada_core",
  "namada_macros",
  "prost",
- "thiserror 1.0.64",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "namada_parameters"
-version = "0.47.1"
-source = "git+https://github.com/anoma/namada?tag=libs-v0.47.1#c934e9f35b1c0053d6db0ebbb4279e53c599e928"
+version = "0.47.0"
+source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
 dependencies = [
  "namada_core",
  "namada_macros",
@@ -2535,16 +2635,16 @@ dependencies = [
  "namada_tx",
  "namada_vp_env",
  "smooth-operator",
- "thiserror 1.0.64",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "namada_proof_of_stake"
-version = "0.47.1"
-source = "git+https://github.com/anoma/namada?tag=libs-v0.47.1#c934e9f35b1c0053d6db0ebbb4279e53c599e928"
+version = "0.47.0"
+source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
 dependencies = [
  "borsh",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "konst",
  "namada_account",
  "namada_controller",
@@ -2558,28 +2658,28 @@ dependencies = [
  "once_cell",
  "serde",
  "smooth-operator",
- "thiserror 1.0.64",
+ "thiserror 2.0.11",
  "tracing",
 ]
 
 [[package]]
 name = "namada_replay_protection"
-version = "0.47.1"
-source = "git+https://github.com/anoma/namada?tag=libs-v0.47.1#c934e9f35b1c0053d6db0ebbb4279e53c599e928"
+version = "0.47.0"
+source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
 dependencies = [
  "namada_core",
 ]
 
 [[package]]
 name = "namada_shielded_token"
-version = "0.47.1"
-source = "git+https://github.com/anoma/namada?tag=libs-v0.47.1#c934e9f35b1c0053d6db0ebbb4279e53c599e928"
+version = "0.47.0"
+source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
 dependencies = [
  "async-trait",
  "borsh",
  "eyre",
  "futures",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "lazy_static",
  "masp_primitives",
  "masp_proofs",
@@ -2598,10 +2698,10 @@ dependencies = [
  "ripemd",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "smooth-operator",
  "tempfile",
- "thiserror 1.0.64",
+ "thiserror 2.0.11",
  "tracing",
  "typed-builder",
  "xorf",
@@ -2609,12 +2709,12 @@ dependencies = [
 
 [[package]]
 name = "namada_state"
-version = "0.47.1"
-source = "git+https://github.com/anoma/namada?tag=libs-v0.47.1#c934e9f35b1c0053d6db0ebbb4279e53c599e928"
+version = "0.47.0"
+source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
 dependencies = [
  "borsh",
  "clru",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "namada_core",
  "namada_events",
  "namada_gas",
@@ -2626,17 +2726,17 @@ dependencies = [
  "namada_tx",
  "patricia_tree",
  "smooth-operator",
- "thiserror 1.0.64",
+ "thiserror 2.0.11",
  "tracing",
 ]
 
 [[package]]
 name = "namada_storage"
-version = "0.47.1"
-source = "git+https://github.com/anoma/namada?tag=libs-v0.47.1#c934e9f35b1c0053d6db0ebbb4279e53c599e928"
+version = "0.47.0"
+source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
 dependencies = [
  "borsh",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "namada_core",
  "namada_gas",
  "namada_macros",
@@ -2645,14 +2745,14 @@ dependencies = [
  "regex",
  "serde",
  "smooth-operator",
- "thiserror 1.0.64",
+ "thiserror 2.0.11",
  "tracing",
 ]
 
 [[package]]
 name = "namada_systems"
-version = "0.47.1"
-source = "git+https://github.com/anoma/namada?tag=libs-v0.47.1#c934e9f35b1c0053d6db0ebbb4279e53c599e928"
+version = "0.47.0"
+source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -2661,8 +2761,8 @@ dependencies = [
 
 [[package]]
 name = "namada_token"
-version = "0.47.1"
-source = "git+https://github.com/anoma/namada?tag=libs-v0.47.1#c934e9f35b1c0053d6db0ebbb4279e53c599e928"
+version = "0.47.0"
+source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2679,8 +2779,8 @@ dependencies = [
 
 [[package]]
 name = "namada_trans_token"
-version = "0.47.1"
-source = "git+https://github.com/anoma/namada?tag=libs-v0.47.1#c934e9f35b1c0053d6db0ebbb4279e53c599e928"
+version = "0.47.0"
+source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
 dependencies = [
  "konst",
  "namada_core",
@@ -2690,14 +2790,14 @@ dependencies = [
  "namada_tx",
  "namada_tx_env",
  "namada_vp_env",
- "thiserror 1.0.64",
+ "thiserror 2.0.11",
  "tracing",
 ]
 
 [[package]]
 name = "namada_tx"
-version = "0.47.1"
-source = "git+https://github.com/anoma/namada?tag=libs-v0.47.1#c934e9f35b1c0053d6db0ebbb4279e53c599e928"
+version = "0.47.0"
+source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
 dependencies = [
  "ark-bls12-381",
  "bitflags",
@@ -2711,22 +2811,22 @@ dependencies = [
  "namada_events",
  "namada_gas",
  "namada_macros",
- "num-derive 0.4.2",
+ "num-derive",
  "num-traits",
  "prost",
  "prost-types",
  "rand_core",
  "serde",
  "serde_json",
- "sha2 0.9.9",
- "thiserror 1.0.64",
+ "sha2 0.10.8",
+ "thiserror 2.0.11",
  "tonic-build",
 ]
 
 [[package]]
 name = "namada_tx_env"
-version = "0.47.1"
-source = "git+https://github.com/anoma/namada?tag=libs-v0.47.1#c934e9f35b1c0053d6db0ebbb4279e53c599e928"
+version = "0.47.0"
+source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -2735,8 +2835,8 @@ dependencies = [
 
 [[package]]
 name = "namada_tx_prelude"
-version = "0.47.1"
-source = "git+https://github.com/anoma/namada?tag=libs-v0.47.1#c934e9f35b1c0053d6db0ebbb4279e53c599e928"
+version = "0.47.0"
+source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
 dependencies = [
  "borsh",
  "namada_account",
@@ -2757,16 +2857,16 @@ dependencies = [
 
 [[package]]
 name = "namada_vm_env"
-version = "0.47.1"
-source = "git+https://github.com/anoma/namada?tag=libs-v0.47.1#c934e9f35b1c0053d6db0ebbb4279e53c599e928"
+version = "0.47.0"
+source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
 dependencies = [
  "namada_core",
 ]
 
 [[package]]
 name = "namada_vp"
-version = "0.47.1"
-source = "git+https://github.com/anoma/namada?tag=libs-v0.47.1#c934e9f35b1c0053d6db0ebbb4279e53c599e928"
+version = "0.47.0"
+source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -2775,14 +2875,14 @@ dependencies = [
  "namada_tx",
  "namada_vp_env",
  "smooth-operator",
- "thiserror 1.0.64",
+ "thiserror 2.0.11",
  "tracing",
 ]
 
 [[package]]
 name = "namada_vp_env"
-version = "0.47.1"
-source = "git+https://github.com/anoma/namada?tag=libs-v0.47.1#c934e9f35b1c0053d6db0ebbb4279e53c599e928"
+version = "0.47.0"
+source = "git+https://github.com/anoma/namada?rev=46e3477e2ed15b43cc6fb466fd4a9456727e5e0b#46e3477e2ed15b43cc6fb466fd4a9456727e5e0b"
 dependencies = [
  "derivative",
  "masp_primitives",
@@ -2817,20 +2917,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "549e471b99ccaf2f89101bec68f4d244457d5a95a9c3d0672e9564124397741d"
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2841,30 +2927,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "num-derive"
@@ -2883,17 +2949,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 
@@ -2919,16 +2974,14 @@ dependencies = [
 
 [[package]]
 name = "num256"
-version = "0.3.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9b5179e82f0867b23e0b9b822493821f9345561f271364f409c8e4a058367d"
+checksum = "85228c87555ed4e5ddf024e9ef1908b27458b97e56b195af0d9cf1d7db890023"
 dependencies = [
- "lazy_static",
- "num",
- "num-derive 0.3.3",
+ "bnum",
+ "num-integer",
  "num-traits",
  "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -3055,17 +3108,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pest"
-version = "2.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
-dependencies = [
- "memchr",
- "thiserror 1.0.64",
- "ucd-trie",
-]
-
-[[package]]
 name = "petgraph"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3171,6 +3213,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "pre-phase4"
+version = "0.1.0"
+dependencies = [
+ "getrandom",
+ "namada_tx_prelude",
+ "rlsf",
 ]
 
 [[package]]
@@ -3530,20 +3581,11 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.25",
+ "semver",
 ]
 
 [[package]]
@@ -3642,27 +3684,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "serde"
@@ -4189,18 +4213,18 @@ dependencies = [
 
 [[package]]
 name = "typed-builder"
-version = "0.19.1"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06fbd5b8de54c5f7c91f6fe4cebb949be2125d7758e630bb58b1d831dbce600"
+checksum = "cd9d30e3a08026c78f246b173243cf07b3696d274debd26680773b6773c2afc7"
 dependencies = [
  "typed-builder-macro",
 ]
 
 [[package]]
 name = "typed-builder-macro"
-version = "0.19.1"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9534daa9fd3ed0bd911d462a37f172228077e7abf18c18a5f67199d959205f8"
+checksum = "3c36781cc0e46a83726d9879608e4cf6c2505237e263a8eb8c24502989cfdb28"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4227,12 +4251,6 @@ name = "typewit_proc_macros"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e36a83ea2b3c704935a01b4642946aadd445cea40b10935e3f8bd8052b8193d6"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uint"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"
 members = [ "increase_target_staked_ratio",
     "phase2",
     "phase3",
+    "pre-phase4",
     "phase4",
     "phase5",
     "increase_target_staked_ratio",
@@ -13,6 +14,7 @@ members = [ "increase_target_staked_ratio",
 default-members = [
     "phase2",
     "phase3",
+    "pre-phase4",
     "phase4",
     "phase5",
     "increase_target_staked_ratio",
@@ -26,9 +28,9 @@ license = "GPL-3.0"
 version = "0.1.0"
 
 [workspace.dependencies]
-namada_tx_prelude = { git = "https://github.com/anoma/namada", tag = "libs-v0.47.1" }
-namada_proof_of_stake = { git = "https://github.com/anoma/namada", tag = "libs-v0.47.1" }
-namada_ibc = { git = "https://github.com/anoma/namada", tag = "libs-v0.47.1" }
+namada_tx_prelude = { git = "https://github.com/anoma/namada", rev = "46e3477e2ed15b43cc6fb466fd4a9456727e5e0b" }
+namada_proof_of_stake = { git = "https://github.com/anoma/namada", rev = "46e3477e2ed15b43cc6fb466fd4a9456727e5e0b" }
+namada_ibc = { git = "https://github.com/anoma/namada", rev = "46e3477e2ed15b43cc6fb466fd4a9456727e5e0b" }
 rlsf = "0.2.1"
 getrandom = { version = "0.2", features = ["custom"] }
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,9 @@ license = "GPL-3.0"
 version = "0.1.0"
 
 [workspace.dependencies]
-namada_tx_prelude = { git = "https://github.com/anoma/namada", rev = "46e3477e2ed15b43cc6fb466fd4a9456727e5e0b" }
-namada_proof_of_stake = { git = "https://github.com/anoma/namada", rev = "46e3477e2ed15b43cc6fb466fd4a9456727e5e0b" }
-namada_ibc = { git = "https://github.com/anoma/namada", rev = "46e3477e2ed15b43cc6fb466fd4a9456727e5e0b" }
+namada_tx_prelude = { git = "https://github.com/anoma/namada", rev = "66e512225da9c5f13d9e23647cf9c07ab987f1eb" }
+namada_proof_of_stake = { git = "https://github.com/anoma/namada", rev = "66e512225da9c5f13d9e23647cf9c07ab987f1eb" }
+namada_ibc = { git = "https://github.com/anoma/namada", rev = "66e512225da9c5f13d9e23647cf9c07ab987f1eb" }
 rlsf = "0.2.1"
 getrandom = { version = "0.2", features = ["custom"] }
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,9 @@ license = "GPL-3.0"
 version = "0.1.0"
 
 [workspace.dependencies]
-namada_tx_prelude = { git = "https://github.com/anoma/namada", rev = "66e512225da9c5f13d9e23647cf9c07ab987f1eb" }
-namada_proof_of_stake = { git = "https://github.com/anoma/namada", rev = "66e512225da9c5f13d9e23647cf9c07ab987f1eb" }
-namada_ibc = { git = "https://github.com/anoma/namada", rev = "66e512225da9c5f13d9e23647cf9c07ab987f1eb" }
+namada_tx_prelude = { git = "https://github.com/anoma/namada", rev = "db92cfbba3740134c6322603900c36f0ee42c06c" }
+namada_proof_of_stake = { git = "https://github.com/anoma/namada", rev = "db92cfbba3740134c6322603900c36f0ee42c06c" }
+namada_ibc = { git = "https://github.com/anoma/namada", rev = "db92cfbba3740134c6322603900c36f0ee42c06c" }
 rlsf = "0.2.1"
 getrandom = { version = "0.2", features = ["custom"] }
 lazy_static = "1.4.0"

--- a/Earthfile
+++ b/Earthfile
@@ -18,7 +18,7 @@ source:
   COPY --keep-ts Cargo.toml Cargo.lock ./
   COPY --keep-ts --chmod 755 docker/run-wasmopt.sh ./run-wasmopt.sh
   COPY --keep-ts --chmod 755 docker/download-wasmopt.sh ./download-wasmopt.sh
-  COPY --keep-ts --dir phase2 phase3 phase4 phase5 increase_target_staked_ratio update-tx-claim-rewards ./
+  COPY --keep-ts --dir phase2 phase3 pre-phase4 phase4 phase5 increase_target_staked_ratio update-tx-claim-rewards ./
 
 # lint runs cargo clippy on the source code
 lint:

--- a/pre-phase4/Cargo.toml
+++ b/pre-phase4/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "pre-phase4"
+description = "WASM transaction to transition from phase 3 to pre-phase 4 of Namada mainnet."
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+version.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+namada_tx_prelude.workspace = true
+rlsf.workspace = true
+getrandom.workspace = true
+
+[lib]
+crate-type = ["cdylib"]

--- a/pre-phase4/src/lib.rs
+++ b/pre-phase4/src/lib.rs
@@ -1,20 +1,37 @@
 use namada_tx_prelude::*;
+use masp_primitives::transaction::components::I128Sum;
+use std::collections::BTreeMap;
+use masp::encode_asset_type;
+use masp_primitives::convert::AllowedConversion;
+use masp::MaspEpoch;
+use token::storage_key::{masp_conversion_key, masp_reward_precision_key};
+use token::{Denomination, MaspDigitPos};
 
 pub type ChannelId = &'static str;
 pub type BaseToken = &'static str;
-pub type Precision = u128;
+// Valid precisions must be in the intersection of i128 and u128
+pub type Precision = i128;
+
+// The denomination of the targetted token. Since all tokens here are IBC
+// tokens, this is 0.
+const DENOMINATION: Denomination = Denomination(0u8);
 
 const IBC_TOKENS: [(ChannelId, BaseToken, Precision); 6] = [
-    ("channel-1", "uosmo", 1000u128),
-    ("channel-2", "uatom", 1000u128),
-    ("channel-3", "utia", 1000u128),
-    ("channel-0", "stuosmo", 1000u128),
-    ("channel-0", "stuatom", 1000u128),
-    ("channel-0", "stutia", 1000u128),
+    ("channel-1", "uosmo", 1000i128),
+    ("channel-2", "uatom", 1000i128),
+    ("channel-3", "utia", 1000i128),
+    ("channel-0", "stuosmo", 1000i128),
+    ("channel-0", "stuatom", 1000i128),
+    ("channel-0", "stutia", 1000i128),
 ];
 
 #[transaction]
 fn apply_tx(ctx: &mut Ctx, _tx_data: BatchedTx) -> TxResult {
+    // The MASP epoch in which this migration will be applied. This number
+    // controls the number of epochs of conversions created.
+    let target_masp_epoch: MaspEpoch = MaspEpoch::try_from_epoch(Epoch(8000), 4)
+        .expect("failed to construct target masp epoch");
+    
     // Enable IBC deposit/withdraws limits
     for (channel_id, base_token, precision) in IBC_TOKENS {
         let ibc_denom = format!("transfer/{channel_id}/{base_token}");
@@ -22,9 +39,71 @@ fn apply_tx(ctx: &mut Ctx, _tx_data: BatchedTx) -> TxResult {
 
         // Write some null MASP reward data
         let shielded_token_reward_precision_key =
-            token::storage_key::masp_reward_precision_key(&token_address);
+            masp_reward_precision_key(&token_address);
 
         ctx.write(&shielded_token_reward_precision_key, precision)?;
+
+        // Erase the TOK rewards that have been distributed so far
+        let mut asset_types = BTreeMap::new();
+        let mut precision_toks = BTreeMap::new();
+        let mut reward_deltas = BTreeMap::new();
+        // TOK[ep, digit]
+        let mut asset_type = |epoch, digit| {
+            *asset_types.entry((epoch, digit)).or_insert_with(|| {
+                encode_asset_type(
+                    token_address.clone(),
+                    DENOMINATION,
+                    digit,
+                    Some(epoch),
+                )
+                .expect("unable to encode asset type")
+            })
+        };
+        // PRECISION TOK[ep, digit]
+        let mut precision_tok = |epoch, digit| {
+            precision_toks
+                .entry((epoch, digit))
+                .or_insert_with(|| {
+                    AllowedConversion::from(I128Sum::from_pair(
+                        asset_type(epoch, digit),
+                        precision,
+                    ))
+                })
+                .clone()
+        };
+        // -PRECISION TOK[ep, digit] + PRECISION TOK[ep+1, digit]
+        let mut reward_delta = |epoch, digit| {
+            reward_deltas
+                .entry((epoch, digit))
+                .or_insert_with(|| {
+                    -precision_tok(epoch, digit)
+                        + precision_tok(epoch.next().unwrap(), digit)
+                })
+                .clone()
+        };
+        // Write the new TOK conversions to memory
+        for digit in MaspDigitPos::iter() {
+            // -PRECISION TOK[ep, digit] + PRECISION TOK[current_ep, digit]
+            let mut reward: AllowedConversion = I128Sum::zero().into();
+            for epoch in MaspEpoch::iter_bounds_inclusive(
+                MaspEpoch::zero(),
+                target_masp_epoch.prev().unwrap(),
+            )
+            .rev()
+            {
+                // TOK[ep, digit]
+                let asset_type = encode_asset_type(
+                    token_address.clone(),
+                    DENOMINATION,
+                    digit,
+                    Some(epoch),
+                )
+                .expect("unable to encode asset type");
+                reward += reward_delta(epoch, digit);
+                // Write the conversion update to memory
+                ctx.write(&masp_conversion_key(&asset_type), reward.clone())?;
+            }
+        }
     }
 
     Ok(())

--- a/pre-phase4/src/lib.rs
+++ b/pre-phase4/src/lib.rs
@@ -1,0 +1,31 @@
+use namada_tx_prelude::*;
+
+pub type ChannelId = &'static str;
+pub type BaseToken = &'static str;
+pub type Precision = u128;
+
+const IBC_TOKENS: [(ChannelId, BaseToken, Precision); 6] = [
+    ("channel-1", "uosmo", 1000u128),
+    ("channel-2", "uatom", 1000u128),
+    ("channel-3", "utia", 1000u128),
+    ("channel-0", "stuosmo", 1000u128),
+    ("channel-0", "stuatom", 1000u128),
+    ("channel-0", "stutia", 1000u128),
+];
+
+#[transaction]
+fn apply_tx(ctx: &mut Ctx, _tx_data: BatchedTx) -> TxResult {
+    // Enable IBC deposit/withdraws limits
+    for (channel_id, base_token, precision) in IBC_TOKENS {
+        let ibc_denom = format!("transfer/{channel_id}/{base_token}");
+        let token_address = ibc::ibc_token(&ibc_denom).clone();
+
+        // Write some null MASP reward data
+        let shielded_token_reward_precision_key =
+            token::storage_key::masp_reward_precision_key(&token_address);
+
+        ctx.write(&shielded_token_reward_precision_key, precision)?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This PR is based on #38 . This governance upgrade, in addition to setting IBC token precisions, also adjusts/overwrites the precision of the existing allowed conversions in the Merkle tree. For simplicity, this adjustment replaces existing allowed conversions with new ones that do not distribute any rewards. Like #38, the precision here is set to 1000 for demonstrative purposes but this can be changed bearing in mind the already described trade-offs.

Applying this PR instead of just #38 should prevent the conversion tree's entries from getting corrupted. This would mean that end-users that have already shielded their tokens will be able to receive future rewards without having to unshield and reshield them. This PR might also allow for changing the precision of the NAM native token, but this use case would have to be tested specifically (through an integration test) before it is proposed in a testnet. But as this PR stands, rewards that have already been distributed in the past (if any) will still be lost (because no reward NAM is attached to the new conversion tree leaves).

Applying this upgrade might take some time because it involves computing many elliptic curve point multiplications. On x86-64 architecture, these computations take about 2 minutes and 24.814s under the assumption that Merkle tree entries for 2000 MASP epochs are being computed. Furthermore 2000 * 4 * 6 * (32 + 4 + 2*(32 + 16)) bytes = 7 megabytes are written into storage by the upgrade. All the keys created by this upgrade are erased at the beginning of the next MASP epoch.

This governance upgrade can only be applied with https://github.com/anoma/namada/pull/4463 merged in. This is because that PR contains the necessary logic to read conversions from storage and apply them to the conversion tree and table residing in memory.